### PR TITLE
Add xen-netback patch to 4.9.34 kernel

### DIFF
--- a/SOURCES/xen-netback-correctly_schedule_rate-limited_queues.patch
+++ b/SOURCES/xen-netback-correctly_schedule_rate-limited_queues.patch
@@ -1,0 +1,79 @@
+From a242d4a74cc4ec46c5e3d43dd07eb146be4ca233 Mon Sep 17 00:00:00 2001
+From: Wei Liu <wei.liu2@xxxxxxxxxx>
+Date: Tue, 20 Jun 2017 11:49:28 +0100
+Subject: [PATCH] xen-netback: correctly schedule rate-limited queues
+
+Add a flag to indicate if a queue is rate-limited. Test the flag in
+NAPI poll handler and avoid rescheduling the queue if true, otherwise
+we risk locking up the host. The rescheduling shall be done when
+replenishing credit.
+
+Reported-by: Jean-Louis Dupond <jean-louis@xxxxxxxxx>
+Signed-off-by: Wei Liu <wei.liu2@xxxxxxxxxx>
+---
+ drivers/net/xen-netback/common.h    | 1 +
+ drivers/net/xen-netback/interface.c | 6 +++++-
+ drivers/net/xen-netback/netback.c   | 6 +++++-
+ 3 files changed, 11 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/net/xen-netback/common.h b/drivers/net/xen-netback/common.h
+index 3ce1f7d..cb7365b 100644
+--- a/drivers/net/xen-netback/common.h
++++ b/drivers/net/xen-netback/common.h
+@@ -199,6 +199,7 @@ struct xenvif_queue { /* Per-queue data for xenvif */
+ 	unsigned long   remaining_credit;
+ 	struct timer_list credit_timeout;
+ 	u64 credit_window_start;
++	bool rate_limited;
+ 
+ 	/* Statistics */
+ 	struct xenvif_stats stats;
+diff --git a/drivers/net/xen-netback/interface.c b/drivers/net/xen-netback/interface.c
+index 74dc2bf..528f92c 100644
+--- a/drivers/net/xen-netback/interface.c
++++ b/drivers/net/xen-netback/interface.c
+@@ -105,7 +105,11 @@ static int xenvif_poll(struct napi_struct *napi, int budget)
+ 
+ 	if (work_done < budget) {
+ 		napi_complete(napi);
+-		xenvif_napi_schedule_or_enable_events(queue);
++		/* If the queue is rate-limited, it shall be
++		 * rescheduled in the timer callback.
++		 */
++		if (likely(!queue->rate_limited))
++			xenvif_napi_schedule_or_enable_events(queue);
+ 	}
+ 
+ 	return work_done;
+diff --git a/drivers/net/xen-netback/netback.c b/drivers/net/xen-netback/netback.c
+index 47b4810..d9b5b73 100644
+--- a/drivers/net/xen-netback/netback.c
++++ b/drivers/net/xen-netback/netback.c
+@@ -179,6 +179,7 @@ static void tx_add_credit(struct xenvif_queue *queue)
+ 		max_credit = ULONG_MAX; /* wrapped: clamp to ULONG_MAX */
+ 
+ 	queue->remaining_credit = min(max_credit, max_burst);
++	queue->rate_limited = false;
+ }
+ 
+ void xenvif_tx_credit_callback(unsigned long data)
+@@ -685,8 +686,10 @@ static bool tx_credit_exceeded(struct xenvif_queue *queue, unsigned size)
+ 		msecs_to_jiffies(queue->credit_usec / 1000);
+ 
+ 	/* Timer could already be pending in rare cases. */
+-	if (timer_pending(&queue->credit_timeout))
++	if (timer_pending(&queue->credit_timeout)) {
++		queue->rate_limited = true;
+ 		return true;
++	}
+ 
+ 	/* Passed the point where we can replenish credit? */
+ 	if (time_after_eq64(now, next_credit)) {
+@@ -701,6 +704,7 @@ static bool tx_credit_exceeded(struct xenvif_queue *queue, unsigned size)
+ 		mod_timer(&queue->credit_timeout,
+ 			  next_credit);
+ 		queue->credit_window_start = next_credit;
++		queue->rate_limited = true;
+ 
+ 		return true;
+ 	}

--- a/SPECS/kernel.spec
+++ b/SPECS/kernel.spec
@@ -99,7 +99,7 @@
 %endif
 
 # Set pkg_release.
-%define pkg_release 28%{?buildid}%{?dist}
+%define pkg_release 29%{?buildid}%{?dist}
 
 #
 # Three sets of minimum package version requirements in the form of Conflicts.
@@ -197,6 +197,7 @@ Patch10001: export-for-xenfb2.patch
 #Patch10002: xen-apic-id-fix.patch
 #Patch10003: xen-nested-dom0-fix.patch
 Patch10004: xsa216-linux-4.11.patch
+Patch10005: xen-netback-correctly_schedule_rate-limited_queues.patch
 
 %description
 This package provides the Linux kernel (vmlinuz), the core of any
@@ -355,6 +356,7 @@ pushd linux-%{version}-%{release}.%{_target_cpu} > /dev/null
 #%patch10002 -p1
 #%patch10003 -p1
 %patch10004 -p1
+%patch10005 -p1
 
 popd > /dev/null
 
@@ -884,6 +886,9 @@ fi
 %endif
 
 %changelog
+* Tue Jun 27 2017 Jean-Louis Dupond <jean-louis@dupond.be> 4.9.34-29
+- Add xen-netback patch to fix lockup with rate-limiting
+
 * Sun Jun 25 2017 Johnny Hughes <johnny@centos.org> 4.9.34-28
 - Upgraded to upstream 4.9.34
 


### PR DESCRIPTION
This adds the xen-netback patch to the 4.9.34 kernel which fixes server hang when using rate-limiting in Xen.