### PR TITLE
4.9.188-35: Bump to 4.9.188 (XSA-300)

### DIFF
--- a/SOURCES/config-x86_64
+++ b/SOURCES/config-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.9.177 Kernel Configuration
+# Linux/x86 4.9.188 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/SPECS/kernel.spec
+++ b/SPECS/kernel.spec
@@ -8,7 +8,7 @@
 %endif
  
 # Define the version of the Linux Kernel Archive tarball.
-%define LKAver 4.9.184
+%define LKAver 4.9.188
 
 # Define the buildid, if required.
 #define buildid .1
@@ -904,6 +904,9 @@ fi
 %endif
 
 %changelog
+* Tue Aug 06 2019 Karl Johnson <karljohnson.it@gmail.com> - 4.9.188-35
+- Upgraded to 4.9.188
+
 * Mon Jul 01 2019 Anthony PERARD <anthony.perard@citrix.com> - 4.9.184-35
 - Upgraded to 4.9.184
 


### PR DESCRIPTION
Package 4.9.188-35 tested on el6, no dmesg regressions.

```
[root@node-dev1 ~]# cat /proc/version 
Linux version 4.9.188-35.el6.x86_64 (mockbuild@build.aerisnetwork.net) (gcc version 4.4.7 20120313 (Red Hat 4.4.7-23) (GCC) ) #1 SMP Tue Aug 6 15:00:25 EDT 2019
```