### PR TITLE
4.9.212-36: Bump to 4.9.212

### DIFF
--- a/SOURCES/config-x86_64
+++ b/SOURCES/config-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.9.206 Kernel Configuration
+# Linux/x86 4.9.212 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/SPECS/kernel.spec
+++ b/SPECS/kernel.spec
@@ -8,7 +8,7 @@
 %endif
  
 # Define the version of the Linux Kernel Archive tarball.
-%define LKAver 4.9.206
+%define LKAver 4.9.212
 
 # Define the buildid, if required.
 #define buildid .1
@@ -904,6 +904,9 @@ fi
 %endif
 
 %changelog
+* Wed Jan 29 2020 Karl Johnson <karljohnson.it@gmail.com> - 4.9.212-36
+- Upgraded to 4.9.212
+
 * Fri Dec 6 2019 Karl Johnson <karljohnson.it@gmail.com> - 4.9.206-36
 - Upgraded to 4.9.206
 - Set CONFIG_X86_INTEL_TSX_MODE_AUTO to Y


### PR DESCRIPTION
Tested on el6:

```
[root@node-dev1 ~]# cat /proc/version 
Linux version 4.9.212-36.el6.x86_64 (mockbuild@build.aerisnetwork.net) (gcc version 4.4.7 20120313 (Red Hat 4.4.7-23) (GCC) ) #1 SMP Wed Jan 29 14:43:45 EST 2020
```