### PR TITLE
Bump to 4.9.215

### DIFF
--- a/SOURCES/config-x86_64
+++ b/SOURCES/config-x86_64
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/x86 4.9.212 Kernel Configuration
+# Linux/x86 4.9.215 Kernel Configuration
 #
 CONFIG_64BIT=y
 CONFIG_X86_64=y

--- a/SPECS/kernel.spec
+++ b/SPECS/kernel.spec
@@ -8,7 +8,7 @@
 %endif
  
 # Define the version of the Linux Kernel Archive tarball.
-%define LKAver 4.9.212
+%define LKAver 4.9.215
 
 # Define the buildid, if required.
 #define buildid .1
@@ -904,6 +904,9 @@ fi
 %endif
 
 %changelog
+* Fri Feb 28 2020 Karl Johnson <karljohnson.it@gmail.com> - 4.9.215-36
+- Upgraded to 4.9.215
+
 * Wed Jan 29 2020 Karl Johnson <karljohnson.it@gmail.com> - 4.9.212-36
 - Upgraded to 4.9.212
 


### PR DESCRIPTION
QA on el6:

```
[root@node-dev1 ~]# cat /proc/version 
Linux version 4.9.215-36.el6.x86_64 (mockbuild@build.aerisnetwork.net) (gcc version 4.4.7 20120313 (Red Hat 4.4.7-23) (GCC) ) #1 SMP Fri Feb 28 13:25:28 EST 2020
```

I opened a request to add devtoolset-8 on the CBS so we can switch to GCC8 on next release.

https://bugs.centos.org/view.php?id=17096